### PR TITLE
updates/dynamic-spm

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "DiskCache",
+            type: .dynamic,
             targets: ["DiskCache"]),
     ],
     dependencies: [


### PR DESCRIPTION
This makes DiskCache a dynamic framework when building with SPM. Noticed that building as a static framework throws errors in the Associate app.