### PR TITLE
feature/async

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,14 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "DiskCache",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Sources/DiskCache/Cache.swift
+++ b/Sources/DiskCache/Cache.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 public protocol Cache {
-    func cache(_ data: Data, key: String) throws
-    func data(_ key: String) throws -> Data?
-    func delete(_ key: String) throws
-    func deleteAll() throws
+    func cache(_ data: Data, key: String) async throws
+    func data(_ key: String) async throws -> Data?
+    func delete(_ key: String) async throws
+    func deleteAll() async throws
     func fileURL(_ filename: String) -> URL
 }

--- a/Sources/DiskCache/Cache.swift
+++ b/Sources/DiskCache/Cache.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public protocol Cache {
     func cache(_ data: Data, key: String) async throws
-    func data(_ key: String) async throws -> Data?
+    func data(_ key: String) async throws -> Data
     func delete(_ key: String) async throws
     func deleteAll() async throws
     func fileURL(_ filename: String) -> URL

--- a/Sources/DiskCache/DiskCache.swift
+++ b/Sources/DiskCache/DiskCache.swift
@@ -9,8 +9,7 @@ import Foundation
 
 typealias VoidCheckedContinuation = CheckedContinuation<Void, Error>
 
-/// Provides interfaces for caching and retrieving data to/from disk. This implementation executes
-/// all tasks on the current queue. Consumers should manage dispatching tasks to background queues if needed
+/// Provides interfaces for caching and retrieving data to/from disk.
 public class DiskCache: Cache {
     lazy var queue = DispatchQueue.global()
     let storageType: StorageType
@@ -29,7 +28,7 @@ public class DiskCache: Cache {
                 return
             }
 
-            queue.async {
+            self.queue.async {
                 do {
                     try data.write(to: self.fileURL(key))
                     continuation.resume()

--- a/Sources/DiskCache/DiskCache.swift
+++ b/Sources/DiskCache/DiskCache.swift
@@ -20,7 +20,7 @@ public class DiskCache: Cache {
     }
 
     public func cache(_ data: Data, key: String) async throws {
-        try await withCheckedThrowingContinuation { [weak self] (continuation: VoidCheckedContinuation) -> Void in
+        try await withUnsafeThrowingContinuation { [weak self] (continuation: VoidCheckedContinuation) -> Void in
             guard let self = self else {
                 return
             }
@@ -37,7 +37,7 @@ public class DiskCache: Cache {
     }
 
     public func data(_ key: String) async throws -> Data {
-        try await withCheckedThrowingContinuation { [weak self] continuation in
+        try await withUnsafeThrowingContinuation { [weak self] continuation in
             guard let self = self else {
                 return
             }
@@ -54,7 +54,7 @@ public class DiskCache: Cache {
     }
 
     public func delete(_ key: String) async throws {
-        try await withCheckedThrowingContinuation { [weak self] (continuation: VoidCheckedContinuation) -> Void in
+        try await withUnsafeThrowingContinuation { [weak self] (continuation: VoidCheckedContinuation) -> Void in
             guard let self = self else {
                 return
             }
@@ -71,7 +71,7 @@ public class DiskCache: Cache {
     }
 
     public func deleteAll() async throws {
-        try await withCheckedThrowingContinuation { [weak self] (continuation: VoidCheckedContinuation) -> Void in
+        try await withUnsafeThrowingContinuation { [weak self] (continuation: VoidCheckedContinuation) -> Void in
             guard let self = self else {
                 return
             }

--- a/Sources/DiskCache/DiskCache.swift
+++ b/Sources/DiskCache/DiskCache.swift
@@ -97,7 +97,7 @@ public class DiskCache: Cache {
     }
 }
 
-private extension DiskCache {
+extension DiskCache {
     var searchPathDirectory: FileManager.SearchPathDirectory? {
         switch storageType {
         case .temporary: return .cachesDirectory
@@ -118,7 +118,7 @@ private extension DiskCache {
 
                 return searchPath
 
-            case .shared(let appGroupID):
+            case let .shared(appGroupID, _):
                 guard let sharedPath = FileManager.default
                         .containerURL(forSecurityApplicationGroupIdentifier: appGroupID)
                 else {

--- a/Sources/DiskCache/DiskCache.swift
+++ b/Sources/DiskCache/DiskCache.swift
@@ -22,7 +22,6 @@ public class DiskCache: Cache {
     public func cache(_ data: Data, key: String) async throws {
         try await withCheckedThrowingContinuation { [weak self] (continuation: VoidCheckedContinuation) -> Void in
             guard let self = self else {
-                continuation.resume()
                 return
             }
 
@@ -37,10 +36,9 @@ public class DiskCache: Cache {
         }
     }
 
-    public func data(_ key: String) async throws -> Data? {
+    public func data(_ key: String) async throws -> Data {
         try await withCheckedThrowingContinuation { [weak self] continuation in
             guard let self = self else {
-                continuation.resume(returning: nil)
                 return
             }
 
@@ -58,7 +56,6 @@ public class DiskCache: Cache {
     public func delete(_ key: String) async throws {
         try await withCheckedThrowingContinuation { [weak self] (continuation: VoidCheckedContinuation) -> Void in
             guard let self = self else {
-                continuation.resume()
                 return
             }
 
@@ -76,7 +73,6 @@ public class DiskCache: Cache {
     public func deleteAll() async throws {
         try await withCheckedThrowingContinuation { [weak self] (continuation: VoidCheckedContinuation) -> Void in
             guard let self = self else {
-                continuation.resume()
                 return
             }
 

--- a/Sources/DiskCache/StorageType.swift
+++ b/Sources/DiskCache/StorageType.swift
@@ -15,7 +15,7 @@ public enum StorageType {
     // stores data in user's `directory` directory
     case permanent(SubDirectory?)
     // stores data in shared container, which is suitable to share data between app, extenstions, etc
-    case shared(AppGroupID)
+    case shared(AppGroupID, SubDirectory?)
 
     var subDirectory: String? {
         switch self {
@@ -23,8 +23,8 @@ public enum StorageType {
             return subDirectory?.value
         case .permanent(let subDirectory):
             return subDirectory?.value
-        case .shared(let appGroupID):
-            return appGroupID
+        case let .shared(_, subDirectory):
+            return subDirectory?.value
         }
     }
 }

--- a/Sources/DiskCache/StorageType.swift
+++ b/Sources/DiskCache/StorageType.swift
@@ -7,9 +7,15 @@
 
 import Foundation
 
+public typealias AppGroupID = String
+
 public enum StorageType {
+    // stores data in user's `caches` directory, which is volatile
     case temporary(SubDirectory?)
+    // stores data in user's `directory` directory
     case permanent(SubDirectory?)
+    // stores data in shared container, which is suitable to share data between app, extenstions, etc
+    case shared(AppGroupID)
 
     var subDirectory: String? {
         switch self {
@@ -17,6 +23,8 @@ public enum StorageType {
             return subDirectory?.value
         case .permanent(let subDirectory):
             return subDirectory?.value
+        case .shared(let appGroupID):
+            return appGroupID
         }
     }
 }

--- a/Tests/DiskCacheTests/DiskCacheTests.swift
+++ b/Tests/DiskCacheTests/DiskCacheTests.swift
@@ -1,6 +1,4 @@
 import XCTest
 @testable import DiskCache
 
-final class DiskCacheTests: XCTestCase {
-    static var allTests = [()]
-}
+final class DiskCacheTests: XCTestCase {}

--- a/Tests/DiskCacheTests/DiskCacheTests.swift
+++ b/Tests/DiskCacheTests/DiskCacheTests.swift
@@ -1,4 +1,25 @@
 import XCTest
 @testable import DiskCache
 
-final class DiskCacheTests: XCTestCase {}
+final class DiskCacheTests: XCTestCase {
+    func testTemporaryStoragePath() throws {
+        let cache = try DiskCache(storageType: .temporary(.custom("temp")))
+        let pathCompnents = cache.directoryURL.pathComponents
+
+        XCTAssertEqual(pathCompnents.suffix(3), ["Caches", "com.mobelux.cache", "temp"])
+    }
+
+    func testPermanentStoragePath() throws {
+        let cache = try DiskCache(storageType: .permanent(.custom("perm")))
+        let pathCompnents = cache.directoryURL.pathComponents
+
+        XCTAssertEqual(pathCompnents.suffix(3), ["Documents", "com.mobelux.cache", "perm"])
+    }
+
+    func testSharedStoragePath() throws {
+        let cache = try DiskCache(storageType: .shared("app-group-id", .custom("shared")))
+        let pathCompnents = cache.directoryURL.pathComponents
+
+        XCTAssertEqual(pathCompnents.suffix(4), ["Group Containers", "app-group-id", "com.mobelux.cache", "shared"])
+    }
+}

--- a/Tests/DiskCacheTests/DiskCacheTests.swift
+++ b/Tests/DiskCacheTests/DiskCacheTests.swift
@@ -1,7 +1,11 @@
+import Foundation
 import XCTest
 @testable import DiskCache
 
 final class DiskCacheTests: XCTestCase {
+    static let testData = "test-data".data(using: .utf8)!
+    static let cacheKey = "cache-key"
+
     func testTemporaryStoragePath() throws {
         let cache = try DiskCache(storageType: .temporary(.custom("temp")))
         let pathCompnents = cache.directoryURL.pathComponents
@@ -21,5 +25,23 @@ final class DiskCacheTests: XCTestCase {
         let pathCompnents = cache.directoryURL.pathComponents
 
         XCTAssertEqual(pathCompnents.suffix(4), ["Group Containers", "app-group-id", "com.mobelux.cache", "shared"])
+    }
+
+    func testCacheData() async throws {
+        let cache = try DiskCache(storageType: .permanent(nil))
+        try await cache.cache(Self.testData, key: Self.cacheKey)
+
+        var data = try await cache.data(Self.cacheKey)
+
+        XCTAssertEqual(data, Self.testData)
+
+        try await cache.delete(Self.cacheKey)
+
+        do {
+            data = try await cache.data(Self.cacheKey)
+            XCTFail("Expected to throw but did not")
+        } catch let error as NSError {
+            XCTAssertEqual(NSFileReadNoSuchFileError, error.code)
+        }
     }
 }

--- a/Tests/DiskCacheTests/XCTestManifests.swift
+++ b/Tests/DiskCacheTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(DiskCacheTests.allTests),
-    ]
-}
-#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import DiskCacheTests
-
-var tests = [XCTestCaseEntry]()
-tests += DiskCacheTests.allTests()
-XCTMain(tests)


### PR DESCRIPTION
Adds async support to caching methods. I considered changing `DiskCache` to be an `actor` type but decided against it because it itself does not manage any sort of mutable state, which seems to be the core reason for an actor.
I did add a worker queue to ensure operations will be executed on the same queue.

I also removed the `appGroupID` property in favor of adding a `shared` case to `StorageType`. This just made good sense.
This diff is a pretty big breaking change, so it will be versioned to `2.0`

- add async support to potentially long running operations
- add missing self
- define shared storage type
- add shared subdirectory and storage path tests
- added cache test, return from data() no longer optional
