### PR TITLE
refactor/remove queue

### DIFF
--- a/Sources/DiskCache/DiskCache.swift
+++ b/Sources/DiskCache/DiskCache.swift
@@ -13,11 +13,17 @@ typealias VoidUnsafeContinuation = UnsafeContinuation<Void, Error>
 public class DiskCache: Cache {
     let storageType: StorageType
 
+    /// Intializes a new instance of `DiskCache`. The path to the cache is created if not already presents. Throws if path cannot be created for some reason.
+    /// - Parameter storageType: The type of storage (on disk) the cache uses. This influences where the cache will be created.
     public required init(storageType: StorageType) throws {
         self.storageType = storageType
         try createDirectory(directoryURL)
     }
 
+    /// Asycronously writes `data` to disk.
+    /// - Parameters:
+    ///   - data: The data to write to disk
+    ///   - key: A unique key used to identify `data`.
     public func cache(_ data: Data, key: String) async throws {
         try await withUnsafeThrowingContinuation {(continuation: VoidUnsafeContinuation) -> Void in
             do {
@@ -29,6 +35,9 @@ public class DiskCache: Cache {
         }
     }
 
+    /// Asycronously get data from the cache. If data does not exist for `key`, an error with code `NSFileReadNoSuchFileError` will be thrown.
+    /// - Parameter key: A unique key used to identify `data`.
+    /// - Returns: An instance of Data which was previously stored on disk.
     public func data(_ key: String) async throws -> Data {
         try await withUnsafeThrowingContinuation { continuation in
             do {
@@ -40,6 +49,8 @@ public class DiskCache: Cache {
         }
     }
 
+    /// Asycronously deletes cached data. If data does not exist for `key`, an error with code `NSFileReadNoSuchFileError` will be thrown.
+    /// - Parameter key: A unique key used to identify `data`.
     public func delete(_ key: String) async throws {
         try await withUnsafeThrowingContinuation { (continuation: VoidUnsafeContinuation) -> Void in
             do {
@@ -51,6 +62,7 @@ public class DiskCache: Cache {
         }
     }
 
+    /// Deletes the cache directory and all or its contents, then recreates the cache directory.
     public func deleteAll() async throws {
         try await withUnsafeThrowingContinuation { (continuation: VoidUnsafeContinuation) -> Void in
             do {
@@ -63,8 +75,11 @@ public class DiskCache: Cache {
         }
     }
 
-    public func fileURL(_ filename: String) -> URL {
-        return directoryURL.appendingPathComponent(filename)
+    /// Constructs the full file url for the given key. Useful for determiniing if a something is cached for the key.
+    /// - Parameter key: A unique key used to identify `data`.
+    /// - Returns: The file url for a cached it, based on `storageType`
+    public func fileURL(_ key: String) -> URL {
+        return directoryURL.appendingPathComponent(key)
     }
 }
 

--- a/Sources/DiskCache/DiskCache.swift
+++ b/Sources/DiskCache/DiskCache.swift
@@ -20,7 +20,7 @@ public class DiskCache: Cache {
         try createDirectory(directoryURL)
     }
 
-    /// Asycronously writes `data` to disk.
+    /// Asynchronously writes `data` to disk.
     /// - Parameters:
     ///   - data: The data to write to disk
     ///   - key: A unique key used to identify `data`.
@@ -35,7 +35,7 @@ public class DiskCache: Cache {
         }
     }
 
-    /// Asycronously get data from the cache. If data does not exist for `key`, an error with code `NSFileReadNoSuchFileError` will be thrown.
+    /// Asynchronously get data from the cache. If data does not exist for `key`, an error with code `NSFileReadNoSuchFileError` will be thrown.
     /// - Parameter key: A unique key used to identify `data`.
     /// - Returns: An instance of Data which was previously stored on disk.
     public func data(_ key: String) async throws -> Data {
@@ -49,7 +49,7 @@ public class DiskCache: Cache {
         }
     }
 
-    /// Asycronously deletes cached data. If data does not exist for `key`, an error with code `NSFileReadNoSuchFileError` will be thrown.
+    /// Asynchronously deletes cached data. If data does not exist for `key`, an error with code `NSFileReadNoSuchFileError` will be thrown.
     /// - Parameter key: A unique key used to identify `data`.
     public func delete(_ key: String) async throws {
         try await withUnsafeThrowingContinuation { (continuation: VoidUnsafeContinuation) -> Void in


### PR DESCRIPTION
Removes the internal dispatch queue and self from the capture list. It appears neither are all that necessary.

- remove queue and self from capture list
- add header docs
