### PR TITLE
Documentation Catalog and Additional Docs

### DIFF
--- a/Sources/DiskCache/Cache.swift
+++ b/Sources/DiskCache/Cache.swift
@@ -7,16 +7,49 @@
 
 import Foundation
 
+/// A class of types providing interfaces for caching and retrieving data to/from disk.
 public protocol Cache {
+
+    /// Synchronously writes `data` to disk.
+    /// - Parameters:
+    ///   - data: The data to write to disk.
+    ///   - key: A unique key used to identify `data`.
     func syncCache(_ data: Data, key: String) throws
+
+    /// Synchronously get data from the cache. If data does not exist for `key`, an error will be thrown.
+    /// - Parameter key: A unique key used to identify `data`.
+    /// - Returns: An instance of Data which was previously stored on disk.
     func syncData(_ key: String) throws -> Data
+
+    /// Synchronously deletes cached data. If data does not exist for `key`, an error will be thrown.
+    /// - Parameter key: A unique key used to identify `data`.
     func syncDelete(_ key: String) throws
+
+    /// Deletes the cache directory and all or its contents, then recreates the cache directory.
     func syncDeleteAll() throws
+
+    /// Constructs the full file url for the given key. Useful for determiniing if a something is cached for the key.
+    /// - Parameter key: A unique key used to identify `data`.
+    /// - Returns: The file url for a cached it, based on `storageType`.
     func fileURL(_ key: String) -> URL
 
     // Async support
+
+    /// Asynchronously writes `data` to disk.
+    /// - Parameters:
+    ///   - data: The data to write to disk.
+    ///   - key: A unique key used to identify `data`.
     func cache(_ data: Data, key: String) async throws
+
+    /// Asynchronously get data from the cache. If data does not exist for `key`, an error will be thrown.
+    /// - Parameter key: A unique key used to identify `data`.
+    /// - Returns: An instance of Data which was previously stored on disk.
     func data(_ key: String) async throws -> Data
+
+    /// Asynchronously deletes cached data. If data does not exist for `key`, an error will be thrown.
+    /// - Parameter key: A unique key used to identify `data`.
     func delete(_ key: String) async throws
+
+    /// Deletes the cache directory and all or its contents, then recreates the cache directory.
     func deleteAll() async throws
 }

--- a/Sources/DiskCache/DiskCache.swift
+++ b/Sources/DiskCache/DiskCache.swift
@@ -26,7 +26,7 @@ public class DiskCache: Cache {
 public extension DiskCache {
     /// Asynchronously writes `data` to disk.
     /// - Parameters:
-    ///   - data: The data to write to disk
+    ///   - data: The data to write to disk.
     ///   - key: A unique key used to identify `data`.
     func cache(_ data: Data, key: String) async throws {
         try await withUnsafeThrowingContinuation {(continuation: VoidUnsafeContinuation) -> Void in
@@ -80,7 +80,7 @@ public extension DiskCache {
 
     /// Constructs the full file url for the given key. Useful for determiniing if a something is cached for the key.
     /// - Parameter key: A unique key used to identify `data`.
-    /// - Returns: The file url for a cached it, based on `storageType`
+    /// - Returns: The file url for a cached it, based on `storageType`.
     func fileURL(_ key: String) -> URL {
         return directoryURL.appendingPathComponent(key)
     }
@@ -90,8 +90,8 @@ public extension DiskCache {
 public extension DiskCache {
     /// Synchronously writes `data` to disk.
     /// - Parameters:
-    ///   - data: The data to write to disk
-    ///   - key: A unique key used to identify `data`
+    ///   - data: The data to write to disk.
+    ///   - key: A unique key used to identify `data`.
     func syncCache(_ data: Data, key: String) throws {
         try data.write(to: fileURL(key))
     }

--- a/Sources/DiskCache/Documentation.docc/DiskCache.md
+++ b/Sources/DiskCache/Documentation.docc/DiskCache.md
@@ -1,0 +1,11 @@
+# ``DiskCache``
+
+A lightweight local cache lib written in Swift.
+
+## Overview
+
+DiskCache is lightweight caching libary intended to persist arbitrary data to disk.
+
+## Topics
+
+### Essentials

--- a/Sources/DiskCache/StorageType.swift
+++ b/Sources/DiskCache/StorageType.swift
@@ -7,14 +7,16 @@
 
 import Foundation
 
+/// An identifier specifying a group to which an app belongs.
 public typealias AppGroupID = String
 
+/// A location where data may be stored.
 public enum StorageType {
-    // stores data in user's `caches` directory, which is volatile
+    /// Stores data in user's `caches` directory, which is volatile.
     case temporary(_ subDirectory: SubDirectory? = nil)
-    // stores data in user's `directory` directory
+    /// Stores data in user's `directory` directory.
     case permanent(_ subDirectory: SubDirectory? = nil)
-    // stores data in shared container, which is suitable to share data between app, extenstions, etc
+    /// Stores data in shared container, which is suitable to share data between app, extenstions, etc.
     case shared(_ appGroupID: AppGroupID, subDirectory: SubDirectory? = nil)
 
     var subDirectory: String? {

--- a/Sources/DiskCache/SubDirectory.swift
+++ b/Sources/DiskCache/SubDirectory.swift
@@ -8,8 +8,11 @@
 
 import Foundation
 
+/// A subdirectory of a ``StorageType`` where data is stored.
 public enum SubDirectory {
+    /// An `images` subdirectory.
     case images
+    /// A subdirectory with a custom name.
     case custom(String)
 
     var value: String {


### PR DESCRIPTION
Adds a documentation catalog and documentation for remaining public types and methods.

On Xcode 15 (I think this is new), if a package exports any of its dependencies, the dependencies' public types appear in the package's documentation catalog. This fixes blank spaces in that parent catalog.