### PR TITLE
Sendable Conformance

### DIFF
--- a/Sources/DiskCache/Cache.swift
+++ b/Sources/DiskCache/Cache.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A class of types providing interfaces for caching and retrieving data to/from disk.
-public protocol Cache {
+public protocol Cache: Sendable {
 
     /// Synchronously writes `data` to disk.
     /// - Parameters:

--- a/Sources/DiskCache/DiskCache.swift
+++ b/Sources/DiskCache/DiskCache.swift
@@ -10,7 +10,7 @@ import Foundation
 typealias VoidUnsafeContinuation = UnsafeContinuation<Void, Error>
 
 /// Provides interfaces for caching and retrieving data to/from disk.
-public class DiskCache: Cache {
+public final class DiskCache: Cache {
     let storageType: StorageType
 
     /// Intializes a new instance of `DiskCache`. The path to the cache is created if not already presents. Throws if path cannot be created for some reason.

--- a/Sources/DiskCache/StorageType.swift
+++ b/Sources/DiskCache/StorageType.swift
@@ -11,7 +11,7 @@ import Foundation
 public typealias AppGroupID = String
 
 /// A location where data may be stored.
-public enum StorageType {
+public enum StorageType: Sendable {
     /// Stores data in user's `caches` directory, which is volatile.
     case temporary(_ subDirectory: SubDirectory? = nil)
     /// Stores data in user's `directory` directory.

--- a/Sources/DiskCache/SubDirectory.swift
+++ b/Sources/DiskCache/SubDirectory.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A subdirectory of a ``StorageType`` where data is stored.
-public enum SubDirectory {
+public enum SubDirectory: Sendable {
     /// An `images` subdirectory.
     case images
     /// A subdirectory with a custom name.


### PR DESCRIPTION
Declares `Sendable` conformances for relevant types. 

**NOTE**: this did require specifying `DiskCache` as `final`